### PR TITLE
Making migrations run only once on deploy

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -23,9 +23,11 @@ func deployContainer() error {
 	if err := pushContainer(); err != nil {
 		return errors.WithStack(err)
 	}
+
 	if err := releaseContainer(); err != nil {
 		return errors.WithStack(err)
 	}
+
 	return runMigrations()
 }
 
@@ -48,7 +50,8 @@ func releaseContainer() error {
 	if err != nil {
 		return errors.WithStack(err)
 	}
-	return runMigrations()
+
+	return nil
 }
 func init() {
 	herokuCmd.AddCommand(deployCmd)

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -103,6 +103,7 @@ func init() {
 	herokuCmd.AddCommand(setupCmd)
 }
 
+//Setup holds the settings to setup the app
 type Setup struct {
 	AppName       string
 	Environment   string
@@ -115,6 +116,7 @@ type Setup struct {
 	Interactive   bool
 }
 
+//Run runs setup steps
 func (s Setup) Run() error {
 	g := makr.New()
 	g.Add(makr.Func{


### PR DESCRIPTION
Related to #3 
cc @markbates 